### PR TITLE
Version format in filename has changed

### DIFF
--- a/repeatmasker.rb
+++ b/repeatmasker.rb
@@ -12,7 +12,7 @@
 class Repeatmasker < Formula
   desc "Nucleic and proteic repeat masking tool"
   homepage "http://www.repeatmasker.org/"
-  version "4.0.5"
+  version "4-0-5"
   url "http://www.repeatmasker.org/RepeatMasker-open-#{version}.tar.gz"
   sha256 "e4c15c64b90d57ce2448df4c49c37529eeb725e97f3366cc90f794a4c0caeef7"
   revision 2


### PR DESCRIPTION
Looks like the repeat masker filename format changed - the version "4.0.5" is now "4-0-5" in the filename.
E.g. old url http://www.repeatmasker.org/RepeatMasker-open-4.0.5.tar.gz  gives a 404 while the new url
http://www.repeatmasker.org/RepeatMasker-open-4-0-5.tar.gz works ok