### PR TITLE
Remove bugfix that is no longer compatible

### DIFF
--- a/mysql-client.rb
+++ b/mysql-client.rb
@@ -48,10 +48,7 @@ class MysqlClient < Formula
     inreplace "cmake/libutils.cmake",
       "COMMAND /usr/bin/libtool -static -o ${TARGET_LOCATION}",
       "COMMAND libtool -static -o ${TARGET_LOCATION}"
-
-    #Patch according to this error https://bugs.mysql.com/bug.php?id=62578
-    inreplace "vio/viosocket.c", "r = read(vio->sd, buf, size);", "while((r = read(vio->sd, buf, size)) == (size_t) -1 && errno == EINTR);"
-    
+   
     # Build without compiler or CPU specific optimization flags to facilitate
     # compilation of gems and other software that queries `mysql-config`.
     ENV.minimal_optimization


### PR DESCRIPTION
The inreplace for the bugfix failed as viosocket.c no longer has a matching line - possibly the bug is fixed? or it has moved? either way the patch here no longer works.