### PR TITLE
Test new formulas on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: "generic"
+
+sudo: required
+services:
+    - docker
+
+install:
+    - docker pull muffato/ensembl-basic-dependencies-linuxbrew
+
+script:
+    - ./travisci/harness.sh
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
     - docker
 
 install:
-    - docker pull muffato/ensembl-basic-dependencies-linuxbrew
+    - docker pull muffato/ensembl-linuxbrew-basic-dependencies
 
 script:
     - ./travisci/harness.sh

--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -6,8 +6,14 @@ set -euo pipefail
 # Enable Ctrl+C if run interactively
 test -t 1 && USE_TTY="-t"
 
-git fetch origin master
-COMMIT_RANGE=${TRAVIS_COMMIT_RANGE:-origin/master..$TRAVIS_BRANCH}
+COMMIT_RANGE="$TRAVIS_COMMIT_RANGE"
+if [ -z "$COMMIT_RANGE" ]
+then
+    # Undo the shallow clone
+    git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+    git fetch --unshallow origin master
+    COMMIT_RANGE="origin/master..$TRAVIS_BRANCH"
+fi
 echo "Testing changed files in $COMMIT_RANGE"
 
 # Test each changed file independently

--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # Enable Ctrl+C if run interactively
 test -t 1 && USE_TTY="-t"
 
-COMMIT_RANGE=${TRAVIS_COMMIT_RANGE:-master..$TRAVIS_BRANCH}
+COMMIT_RANGE=${TRAVIS_COMMIT_RANGE:-origin/master..$TRAVIS_BRANCH}
 echo "Testing changed files in $COMMIT_RANGE"
 
 # Test each changed file independently

--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 # Enable Ctrl+C if run interactively
 test -t 1 && USE_TTY="-t"
 
+git fetch origin master
 COMMIT_RANGE=${TRAVIS_COMMIT_RANGE:-origin/master..$TRAVIS_BRANCH}
 echo "Testing changed files in $COMMIT_RANGE"
 

--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -6,8 +6,11 @@ set -euo pipefail
 # Enable Ctrl+C if run interactively
 test -t 1 && USE_TTY="-t"
 
+COMMIT_RANGE=${TRAVIS_COMMIT_RANGE:-master..$TRAVIS_BRANCH}
+echo "Testing changed files in $COMMIT_RANGE"
+
 # Test each changed file independently
-for filename in $(git diff --name-only "$TRAVIS_COMMIT_RANGE" | grep '\.rb$')
+for filename in $(git diff --name-only "$COMMIT_RANGE" | grep '\.rb$')
 do
     # Notes:
     # - Mount the whole tap to use the new version of each formula

--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 test -t 1 && USE_TTY="-t"
 
 # Test each changed file independently
-for filename in $(git diff --name-only "$TRAVIS_COMMIT_RANGE")
+for filename in $(git diff --name-only "$TRAVIS_COMMIT_RANGE" | grep '\.rb$')
 do
     # Notes:
     # - Mount the whole tap to use the new version of each formula

--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+
+# Enable Ctrl+C if run interactively
+test -t 1 && USE_TTY="-t"
+
+# Test each changed file independently
+for filename in $(git diff --name-only "$TRAVIS_COMMIT_RANGE")
+do
+    # Notes:
+    # - Mount the whole tap to use the new version of each formula
+    # - Don't upgrade the formulae already installed as this image is expected to be updated regularly
+    docker run ${USE_TTY:-} -i \
+               -v "$PWD:/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/ensembl/homebrew-ensembl" \
+               muffato/ensembl-basic-dependencies-linuxbrew \
+               brew install --build-from-source "ensembl/ensembl/$(basename "${filename%.rb}")"
+               #/bin/bash
+done
+

--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -24,7 +24,7 @@ do
     # - Don't upgrade the formulae already installed as this image is expected to be updated regularly
     docker run ${USE_TTY:-} -i \
                -v "$PWD:/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/ensembl/homebrew-ensembl" \
-               muffato/ensembl-basic-dependencies-linuxbrew \
+               muffato/ensembl-linuxbrew-basic-dependencies \
                brew install --build-from-source "ensembl/ensembl/$(basename "${filename%.rb}")"
                #/bin/bash
 done


### PR DESCRIPTION
I've turned the script I use locally to test the new formula in a Docker container to a script that works on Travis. Since it is too expensive to rebuild all the formulas, it first lists the ones that have changed in the commit range.
The script relies on a Docker container that I currently have under my own account, but that I would migrate if this PR is accepted. See https://github.com/muffato/ensembl-tapped-linuxbrew/blob/master/Dockerfile and https://github.com/muffato/ensembl-basic-dependencies-linuxbrew/blob/master/Dockerfile

Disclaimer. Since the docker container is public, it doesn't include the private moonshine stuff. As a result, some formula, like interproscan, may not work on Travis (see the build of this pull-request). But I think it's still generally useful.