### PR TITLE
rewrite_shebang does not work as expected with virtual environments

### DIFF
--- a/orthofinder.rb
+++ b/orthofinder.rb
@@ -28,18 +28,21 @@ class Orthofinder < Formula
   def install
     venv = virtualenv_create(libexec, 'python3')
     system "#{libexec}/bin/pip", 'install', 'numpy', 'scipy'
-    rewrite_shebang detected_python_shebang, 'orthofinder.py',
-                                             'scripts_of/__main__.py',
-                                             'scripts_of/consensus_tree.py',
-                                             'scripts_of/files.py',
-                                             'scripts_of/orthologues.py',
-                                             'scripts_of/program_caller.py',
-                                             'scripts_of/stag.py',
-                                             'scripts_of/stride.py',
-                                             'scripts_of/trim.py',
-                                             'scripts_of/trees_msa.py',
-                                             'tools/convert_orthofinder_tree_ids.py',
-                                             'tools/make_ultrametric.py'
+    # Replace shebang with virtualenv python
+    venv_shebang = python_shebang_rewrite_info("#{libexec}/bin/python")
+    rewrite_shebang venv_shebang, 'orthofinder.py',
+                                  'scripts_of/__main__.py',
+                                  'scripts_of/consensus_tree.py',
+                                  'scripts_of/files.py',
+                                  'scripts_of/orthologues.py',
+                                  'scripts_of/program_caller.py',
+                                  'scripts_of/stag.py',
+                                  'scripts_of/stride.py',
+                                  'scripts_of/trees_msa.py',
+                                  'scripts_of/trim.py',
+                                  'tools/convert_orthofinder_tree_ids.py',
+                                  'tools/create_files_for_hogs.py',
+                                  'tools/make_ultrametric.py'
     # Remove local binaries so the homebrew ones are used instead
     system 'rm', '-rf', 'scripts_of/bin'
     bin.install "orthofinder.py" => "orthofinder"


### PR DESCRIPTION
`detected_python_shebang` uses the main homebrew's Python (`/hps/software/users/ensembl/ensw/C8-MAR21-sandybridge/linuxbrew/opt/python@3.9/bin/python3` in Codon) instead of the formula's virtual environment (`/hps/software/users/ensembl/ensw/C8-MAR21-sandybridge/linuxbrew/Cellar/orthofinder/2.5.4/libexec/bin/python3` in Codon), so the installed software is unable to run because the required libraries are not found. After @thibauthourlier's suggestion and a luckier search this time (didn't find it when I looked into this yesterday), I have been able to find how to change the default behaviour.

@thiagogenez has done a manual update of these shebangs in the installed version in Codon and OrthoFinder is working now. I have tested the formula locally and it worked as expected.

__Note:__ There was one missing file that needs the shebang replaced as well.