### PR TITLE
adding Dockerfile and a solution to overcome the container's expired SSL certificates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ sudo: required
 services:
     - docker
 
-install:
-    - docker pull muffato/ensembl-linuxbrew-basic-dependencies
+before_install:
+    - docker build -t ensembl/homebrew-ensembl .
 
 script:
     - ./travisci/harness.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# This container (i) disables the DST Root CA X3 certificate 
+# because it has experied on September 2021, and (ii) updates 
+# the directory /etc/ssl/certs that hold SSLs certificates.
+
+FROM muffato/ensembl-linuxbrew-basic-dependencies
+
+RUN sudo sed -i '/^mozilla\/DST_Root_CA_X3/s/^/!/' /etc/ca-certificates.conf \
+ && sudo update-ca-certificates -f
+
+# Unlink linuxbrew's curl as it uses old certificates
+RUN brew unlink curl
+
+# clean up
+RUN sudo apt-get clean \
+ && sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+ && brew cleanup \
+ && rm -rf /home/linuxbrew/.cache/Homebrew

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ FROM muffato/ensembl-linuxbrew-basic-dependencies
 RUN sudo sed -i '/^mozilla\/DST_Root_CA_X3/s/^/!/' /etc/ca-certificates.conf \
  && sudo update-ca-certificates -f
 
+# The above is to avoid the message "Warning: ensembl/external is shallow clone"
+RUN brew untap ensembl/external \
+ && brew tap ensembl/external
+
 # Unlink linuxbrew's curl as it uses old certificates
 RUN brew unlink curl
 

--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -75,7 +75,7 @@ echo "Formulae to test (incl. reverse dependencies):" "${ALL_FORMULAE[@]}"
 docker run ${USE_TTY:-} -i \
        "${MOUNTS[@]}" \
        --env HOMEBREW_NO_AUTO_UPDATE=1 \
-       muffato/ensembl-linuxbrew-basic-dependencies \
+       ensembl/homebrew-ensembl \
        "$TAP_DOCKER_PATH/travisci/test_on_docker.sh" "${ALL_FORMULAE[@]}"
        #/bin/bash
 


### PR DESCRIPTION
 Travis relies on a legacy container that provides an old Linuxbrew (version 1.9.3) and Ubuntu 16.04.5 LTS. However, this Linuxbrew version is no longer being updated, and this Ubuntu version contains a certificate (DST Root CA X3) that expired in September 2021. As a result, Linuxbrew can't cook formulas because downloads fail due to the _SSL certificate problem_ raised during `curl` usage. 

There are two options to overcome this issue:

1. Upgrade the Linuxbrew employed in the original [Dockerfile](https://github.com/muffato/docker-ensembl-linuxbrew-basic-dependencies/blob/master/Dockerfile) to create a new container. The idea behind this solution is to use a Linuxbrew version that matches the version used in our cluster. However, several formulas may require updates.
2. Applying a patch to the current container (registered and stored by [DockerHub](https://hub.docker.com/r/muffato/ensembl-linuxbrew-basic-dependencies)) to update SSL certificates and bypass the _SSL certificate problem_ 

This pull request proposed solution #2.


